### PR TITLE
Fixed issue where the running bashpp in the same directory as the preprocessed file results in incorrect inclusion due incorrect pathing

### DIFF
--- a/bin/bashpp
+++ b/bin/bashpp
@@ -866,7 +866,7 @@ function process_directive_include() {
         includefile=${BASH_REMATCH[1]}
 
         if [[ $includefile != /* ]] ; then
-            includefile="${file%/*}/$includefile"
+            includefile="$(dirname "$file")/$includefile"
         fi
     elif [[ $args =~ ^\<(.+)\>$ ]] ; then
         includefile=${BASH_REMATCH[1]}


### PR DESCRIPTION
Fixes https://github.com/iwonbigbro/bashpp/issues/14
